### PR TITLE
Convert full pdf page to image

### DIFF
--- a/pdf_suite/command_line/command_line.py
+++ b/pdf_suite/command_line/command_line.py
@@ -29,11 +29,12 @@ class CommandLine:
         output: str = typer.Option(..., '--output', '-o', help='Where you gonna find the extracted images.'),
         page: int = typer.Option(None, '--page', '-p', help='The page number that you want.'),
         zipped: bool = typer.Option(False, '--zip', '-z', help='Zip generated images.'),
+        full_page: bool = typer.Option(False, '--full-page', '-f', help='Turn full pages to images.'),
     ) -> None:
         if page and page <= 0:
             raise ValueError("page should be greater than 0")
 
-        pdfToImage().page(page).run(input, output, zipped)
+        pdfToImage().page(page).run(input, output, zipped, full_page)
 
     @app.command()
     def thumbnail(

--- a/pdf_suite/pdf2img.py
+++ b/pdf_suite/pdf2img.py
@@ -9,10 +9,10 @@ from pdf_suite.helper.output import Output
 
 class pdfToImage:
     _pdfFile: Any
-    _page: Optional[int]
+    _page: Optional[int] = None
     _output_folder: str
 
-    def run(self, pdf_path: str, output_folder: str, zipped: bool, only_images: bool = True):
+    def run(self, pdf_path: str, output_folder: str, zipped: bool = False, full_page: bool = False):
         """
         Extracts all images from a PDF and saves them to a specified folder.
         """
@@ -20,18 +20,18 @@ class pdfToImage:
 
         self._pdfFile = fitz.open(pdf_path)
 
-        if only_images:
-            if self._page:
-                self._extract_images_from_page(self._page)
-            else:
-                for page_index in range(len(self._pdfFile)):
-                    self._extract_images_from_page(page_index + 1)
-        else:
+        if full_page:
             if self._page:
                 self._page_to_image(self._page)
             else:
                 for page_index in range(len(self._pdfFile)):
                     self._page_to_image(page_index + 1)
+        else:
+            if self._page:
+                self._extract_images_from_page(self._page)
+            else:
+                for page_index in range(len(self._pdfFile)):
+                    self._extract_images_from_page(page_index + 1)
 
         self._pdfFile.close()
 

--- a/pdf_suite/pdf2img.py
+++ b/pdf_suite/pdf2img.py
@@ -12,7 +12,7 @@ class pdfToImage:
     _page: Optional[int]
     _output_folder: str
 
-    def run(self, pdf_path: str, output_folder: str, zipped: bool):
+    def run(self, pdf_path: str, output_folder: str, zipped: bool, only_images: bool = True):
         """
         Extracts all images from a PDF and saves them to a specified folder.
         """
@@ -20,11 +20,18 @@ class pdfToImage:
 
         self._pdfFile = fitz.open(pdf_path)
 
-        if self._page:
-            self._extract_images_from_page(self._page)
+        if only_images:
+            if self._page:
+                self._extract_images_from_page(self._page)
+            else:
+                for page_index in range(len(self._pdfFile)):
+                    self._extract_images_from_page(page_index + 1)
         else:
-            for page_index in range(len(self._pdfFile)):
-                self._extract_images_from_page(page_index + 1)
+            if self._page:
+                self._page_to_image(self._page)
+            else:
+                for page_index in range(len(self._pdfFile)):
+                    self._page_to_image(page_index + 1)
 
         self._pdfFile.close()
 
@@ -53,6 +60,15 @@ class pdfToImage:
             image_filename = os.path.join(self._output_folder, f"page{page_number}_img{img_index + 1}.{image_ext}")
             with open(Output(image_filename).path(), "wb") as f:
                 f.write(image_bytes)
+
+    def _page_to_image(self, page_number: int) -> None:
+        page = self._pdfFile.load_page(page_number - 1)
+        zoom = 1
+
+        matrix = fitz.Matrix(zoom, zoom)
+        pix = page.get_pixmap(matrix=matrix, alpha=False)
+        image_filename = os.path.join(self._output_folder, f"page{page_number}.jpeg")
+        pix.save(Output(image_filename).path())
 
     def _zip_output(self) -> None:
         zip_file = os.path.join(self._output_folder, "output.zip")


### PR DESCRIPTION
Resolves #30 

Using same command `pdf2img`, you can convert your pdf pages to images by passing `--full-page` option.

### Command

```bash
pdf_suite pdf2img --input input.pdf --output images --full-page
```

### Code

```python
from pdf_suite.pdf2img import pdfToImage

pdfToImage().page(1).run('invoicesample.pdf', 'images', full_page=True)
```